### PR TITLE
[fix] l10n_es_aeat_sii: cambio de orden de imports de modelos

### DIFF
--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import res_company
-from . import account_invoice
 from . import aeat_sii
 from . import aeat_sii_mapping_registration_keys
 from . import aeat_sii_map
+from . import account_invoice


### PR DESCRIPTION
Se ha modificado el orden de los imports puesto que account_invoice depende de aeat_sii_mapping_registration_keys