### PR TITLE
[IMP][8.0] l10n_es_aeat_sii

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -26,9 +26,7 @@ Para configurar este módulo necesitas:
 #. En la compañia se almacenan las URLs del servicio SOAP de hacienda.
 Estas URLs pueden cambiar según comunidades
 #. Los certificados deben alojarse en una carpeta accesible por la instalación
-de Odoo. Las rutas de los certificados se pueden indicar en Configuración->
-Parámetros->Parametros del sistemas con las claves l10n_es_aeat_sii.publicCrt y
-l10n_es_aeat_sii.privateKey
+de Odoo.
 #. Preparar el certificado. El certificado enviado por la FMNT es en formato
 p12, este certificado no se puede usar directamente con Zeep. Se tiene que
 extraer la clave pública y la clave privada.

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -30,6 +30,7 @@
         "data/aeat_sii_mapping_registration_keys_data.xml",
         "views/aeat_sii_map_view.xml",
         "data/aeat_sii_map_data.xml",
-        "security/ir.model.access.csv"
+        "security/ir.model.access.csv",
+        "security/aeat_sii.xml"
     ],
 }

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Ignacio Ibeas <ignacio@acysos.com>
 # (c) 2017 Diagram Software S.L.
-# Copyright (c) 2017-TODAY MINORISA <ramon.guiu@minorisa.net> 
+# Copyright (c) 2017-TODAY MINORISA <ramon.guiu@minorisa.net>
+# (c) 2017 Consultoría Informática Studio 73 S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.1.0.2",
+    "version": "8.0.1.1.0",
     "category": "Accounting & Finance",
     "website": "https://odoo-community.org/",
     "author": "Acysos S.L., Odoo Community Association (OCA)",

--- a/l10n_es_aeat_sii/data/ir_config_parameter.xml
+++ b/l10n_es_aeat_sii/data/ir_config_parameter.xml
@@ -3,16 +3,6 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <openerp>
     <data noupdate="0">
-        <record id="config_parameter_sii_crt" model="ir.config_parameter" forcecreate="True">
-            <field name="key">l10n_es_aeat_sii.publicCrt</field>
-            <field name="value">/opt/certificates/publicCert.crt</field>
-            <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
-        </record>
-        <record id="config_parameter_sii_key" model="ir.config_parameter" forcecreate="True">
-            <field name="key">l10n_es_aeat_sii.privateKey</field>
-            <field name="value">/opt/certificates/privateKey.pem</field>
-            <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
-        </record>
         <record id="config_parameter_sii_version" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.version</field>
             <field name="value">0.7</field>

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -440,7 +440,8 @@ class AccountInvoice(models.Model):
              '|', ('date_start', '=', False),
              ('date_start', '<=', today),
              '|', ('date_end', '=', False),
-             ('date_end', '>=', today)],
+             ('date_end', '>=', today),
+             ('active', '=', True)],
             limit=1
         )
         if not sii_config:

--- a/l10n_es_aeat_sii/models/aeat_sii.py
+++ b/l10n_es_aeat_sii/models/aeat_sii.py
@@ -43,13 +43,8 @@ class l10nEsAeatSii(models.Model):
     @api.multi
     def action_active(self):
         self.ensure_one()
-        if self.public_key:
-            sii_crt = self.env.ref('l10n_es_aeat_sii.config_parameter_sii_crt')
-            sii_crt.value = self.public_key
-        if self.private_key:
-            sii_key = self.env.ref('l10n_es_aeat_sii.config_parameter_sii_key')
-            sii_key.value = self.private_key
-        other_configs = self.search([('id', '!=', self.id)])
+        other_configs = self.search([('id', '!=', self.id),
+                                     ('company_id', '=', self.company_id.id)])
         for config_id in other_configs:
             config_id.state = 'draft'
         self.state = 'active'

--- a/l10n_es_aeat_sii/models/aeat_sii.py
+++ b/l10n_es_aeat_sii/models/aeat_sii.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2017 Diagram Software S.L.
+# (c) 2017 Consultoría Informática Studio 73 S.L.
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import api, models, fields, _
@@ -19,6 +20,12 @@ class l10nEsAeatSii(models.Model):
     date_end = fields.Date(string="End Date")
     public_key = fields.Char(string="Public Key", readonly=True)
     private_key = fields.Char(string="Private Key", readonly=True)
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Compañía",
+        required=True,
+        default=lambda self: self.env.user.company_id.id
+    )
 
     @api.multi
     def load_password_wizard(self):

--- a/l10n_es_aeat_sii/models/res_company.py
+++ b/l10n_es_aeat_sii/models/res_company.py
@@ -20,8 +20,7 @@ class ResCompany(models.Model):
     sii_enabled = fields.Boolean(string='Enable SII')
     sii_test = fields.Boolean(string='Test Enviroment')
     chart_template_id = fields.Many2one(
-        comodel_name='account.chart.template', string='Chart Template',
-        required=True)
+        comodel_name='account.chart.template', string='Chart Template')
     use_connector = fields.Boolean(
         string='Use connector',
         help='Check it to use connector instead to send the invoice '

--- a/l10n_es_aeat_sii/models/res_company.py
+++ b/l10n_es_aeat_sii/models/res_company.py
@@ -2,7 +2,8 @@
 # Copyright 2017 Ignacio Ibeas <ignacio@acysos.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models, fields, api
+from openerp import models, fields, api, _
+from openerp.exceptions import Warning
 
 
 class ResCompany(models.Model):
@@ -10,10 +11,10 @@ class ResCompany(models.Model):
     
     @api.onchange('use_connector')
     def _check_connector_installed(self):
-        module = self.env['ir.module'].search(
+        module = self.env['ir.module.module'].search(
             [('name', '=', 'connector'), ('state', '=', 'installed')])
         if not module:
-            raise exceptions.Warning(
+            raise Warning(
                 _('The module "Connector" is not installed. You have '
                   'to install it to activate this option'))
 

--- a/l10n_es_aeat_sii/security/aeat_sii.xml
+++ b/l10n_es_aeat_sii/security/aeat_sii.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record id="l10n_es_aeat_sii_rule" model="ir.rule">
+            <field name="name">AEAT SII config</field>
+            <field ref="model_l10n_es_aeat_sii" name="model_id"/>
+            <field eval="True" name="global"/>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_es_aeat_sii/security/ir.model.access.csv
+++ b/l10n_es_aeat_sii/security/ir.model.access.csv
@@ -5,3 +5,6 @@ access_model_aeat_sii_map_lines_admin,aeat.sii.map.lines admin,model_aeat_sii_ma
 access_model_aeat_sii_map_lines_aeat,aeat.sii.map.lines aeat,model_aeat_sii_map_lines,l10n_es_aeat.group_account_aeat,1,0,0,0
 access_model_aeat_sii_mapping_registration_keys_admin,aeat.sii.mapping.registration.keys admin,model_aeat_sii_mapping_registration_keys,base.group_system,1,1,1,1
 access_model_aeat_sii_mapping_registration_keys_aeat,aeat.sii.mapping.registration.keys aeat,model_aeat_sii_mapping_registration_keys,l10n_es_aeat.group_account_aeat,1,0,0,0
+access_l10n_es_aeat_sii_admin,l10n.es.aeat.sii admin,model_l10n_es_aeat_sii,base.group_system,1,1,1,1
+access_l10n_es_aeat_sii_aeat,l10n.es.aeat.sii aeat,model_l10n_es_aeat_sii,l10n_es_aeat.group_account_aeat,1,0,0,0
+

--- a/l10n_es_aeat_sii/views/aeat_sii_view.xml
+++ b/l10n_es_aeat_sii/views/aeat_sii_view.xml
@@ -18,6 +18,7 @@
                             <field name="folder"/>
                         </group>
                         <group>
+                            <field name="company_id"/>
                             <field name="date_start"/>
                             <field name="date_end"/>
                         </group>

--- a/l10n_es_aeat_sii/views/aeat_sii_view.xml
+++ b/l10n_es_aeat_sii/views/aeat_sii_view.xml
@@ -18,7 +18,7 @@
                             <field name="folder"/>
                         </group>
                         <group>
-                            <field name="company_id"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="date_start"/>
                             <field name="date_end"/>
                         </group>

--- a/l10n_es_aeat_sii/views/res_company_view.xml
+++ b/l10n_es_aeat_sii/views/res_company_view.xml
@@ -12,7 +12,8 @@
 					<separator name="aeat_sii_config" string="AEAT SII Configuration" />
 					<group><field name="sii_enabled"/></group>
 					<group attrs="{'invisible': [('sii_enabled', '=', False)]}">
-						<field name="chart_template_id"/>
+						<field name="chart_template_id"
+							   attrs="{'required': [('sii_enabled', '=', True)]}"/>
 						<field name="use_connector" />
 						<field name="sii_test" />
 					</group>

--- a/l10n_es_aeat_sii/wizard/aeat_sii_password_view.xml
+++ b/l10n_es_aeat_sii/wizard/aeat_sii_password_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Insert Password">
                     <group>
-                        <field name="password"/>
+                        <field name="password" password="True"/>
                     </group>
                     <footer>
                         <button name="get_keys" type="object" string="Obtain Keys" class="oe_highlight"/>


### PR DESCRIPTION
- Ocultar la contraseña del certificado
- Plantilla de cuentas solo obligatorias si "Activar SII"
- KeyError: 'ir.module', nombre del modelo incorrecto (ir.module.module)
- Certificado por compañía:
    Vincular la clase "l10n.es.aeat.sii" a una compañía y utilizarla para obtener la clave publica y privada en lugar de los parámetros del sistema. 
