### PR TITLE
[IMP] l10n_es_aeat_sii: Envío de facturas rectificativas

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -18,6 +18,7 @@
                    "requests"],
     },
     "depends": [
+        "account_refund_original",
         "l10n_es_aeat",
         "connector",
     ],


### PR DESCRIPTION
- No poder asignar Tipo rectificativa = Por sustitución si no hay facturas rectificadas (Añade dependencia a account_refund_original)
- Si el tipo rectificativa es por sustitución, se añade al envío el importe de rectificación