### PR TITLE
[IMP] l10n_es_aeat_sii: uso condicional de IDOtro/NIF e ImporteTotal en recibidas

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -418,7 +418,8 @@ class AccountInvoice(models.Model):
                     "Contraparte": {
                         "NombreRazon": self.partner_id.name[0:120],
                     },
-                    "TipoDesglose": tipo_desglose
+                    "TipoDesglose": tipo_desglose,
+                    "ImporteTotal": self.amount_total
                 }
             }
             # Uso condicional de IDOtro/NIF

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -417,11 +417,13 @@ class AccountInvoice(models.Model):
                     "DescripcionOperacion": self.sii_description[0:500],
                     "Contraparte": {
                         "NombreRazon": self.partner_id.name[0:120],
-                        "NIF": self.partner_id.vat[2:]
                     },
                     "TipoDesglose": tipo_desglose
                 }
             }
+            # Uso condicional de IDOtro/NIF
+            invoices['FacturaExpedida']['Contraparte'].update(
+                self._get_sii_identifier())
             if self.type == 'out_refund':
                 invoices['FacturaExpedida'][
                     'TipoRectificativa'] = self.refund_type
@@ -623,6 +625,27 @@ class AccountInvoice(models.Model):
         })
 
         return super(AccountInvoice, self).copy(default)    
+
+    @api.multi
+    def _get_sii_identifier(self):
+        self.ensure_one()
+        codPais = self.partner_id.vat[:2]
+        dic_ret = {}
+        if codPais != 'ES':
+            if self.fiscal_position.name == u'Régimen Intracomunitario':
+                idType = '02'
+            else:
+                idType = '04'
+            dic_ret = {
+                "IDOtro": {
+                    "CodigoPais": codPais,
+                    "IDType": idType,
+                    "ID": self.partner_id.vat
+                }
+            }
+        else:
+            dic_ret = {"NIF": self.partner_id.vat[2:]}
+        return dic_ret
 
 
 @job(default_channel='root.invoice_validate_sii')


### PR DESCRIPTION
- El uso de IDOtro/NIF se calcula en _get_sii_identifier
- Se aplica la mod a Contraparte de las emitidas
- Se añade el campo ImporteTotal a recibidas

@AngelCamacho: dejo pendiente la función _get_sii_op_breakdown y cambios que afectan a _get_sii_out_taxes a que se ver loq que pasa con el PR 14 de @RamonGuiuGou (para evitar liarme)
