### PR TITLE
[IMP] l10n_es_aeat_sii: clave registro en posición fiscal y filtros facturas con error

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -36,6 +36,7 @@
         "security/ir.model.access.csv",
         "security/aeat_sii.xml",
         "views/product_view.xml",
+        "views/account_view.xml"
     ],
     "post_init_hook": "add_key_to_existing_invoices",
 }

--- a/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
+++ b/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
@@ -144,6 +144,11 @@ msgid "Date to"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
+#: field:account.fiscal.position,sii_registration_key:0
+msgid "Default SII Resgistration Key"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
 #: field:res.company,delay_time:0
 msgid "Delay time"
 msgstr ""
@@ -394,6 +399,16 @@ msgstr ""
 #. module: l10n_es_aeat_sii
 #: field:account.invoice,sii_sent:0
 msgid "SII Sent"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
+msgid "SII error"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
+msgid "SII failed"
 msgstr ""
 
 #. module: l10n_es_aeat_sii

--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -7,4 +7,5 @@ from . import aeat_sii
 from . import aeat_sii_mapping_registration_keys
 from . import aeat_sii_map
 from . import product_product
+from . import account
 from . import account_invoice

--- a/l10n_es_aeat_sii/models/account.py
+++ b/l10n_es_aeat_sii/models/account.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 FactorLibre - Ismael Calvo <ismael.calvo@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class account_fiscal_position(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    sii_registration_key = fields.Many2one(
+        'aeat.sii.mapping.registration.keys',
+        'Default SII Resgistration Key')

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -105,7 +105,15 @@
                             domain="[('sii_sent','=',False)]" />
                     <filter name="sii_sent" string="SII send"
                             domain="[('sii_sent','=',True)]"/>
+                    <filter name="sii_send_state" string="SII failed"
+                            domain="[('sii_send_error','!=',False)]"/>
                 </filter>
+                <xpath expr="//group[@string='Group By']" position="inside">
+                    <separator/>
+                    <filter string="SII error"
+                        domain="[('sii_send_error','!=',False)]"
+                        context="{'group_by':'sii_send_error'}"/>
+                </xpath>
             </field>
         </record>
 

--- a/l10n_es_aeat_sii/views/account_view.xml
+++ b/l10n_es_aeat_sii/views/account_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 FactorLibre - Ismael Calvo <ismael.calvo@factorlibre.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+
+<openerp>
+    <data>
+
+        <record id="view_account_position_form" model="ir.ui.view">
+            <field name="name">account.fiscal.position.form</field>
+            <field name="model">account.fiscal.position</field>
+            <field name="inherit_id" ref="account.view_account_position_form"/>
+            <field name="arch" type="xml">
+                <field name="country_group_id" position="after">
+                    <field name="sii_registration_key"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Propongo varios cambios:
- Añadir el campo clave de registro a la posición fiscal para que se rellene esa información por defecto en la factura en función de la posición fiscal.
- Un filtro que permite agrupar las facturas según el error que ha dado al enviar al SII